### PR TITLE
Hide <h1> elements with CSS

### DIFF
--- a/royalsScore_REV/index.html
+++ b/royalsScore_REV/index.html
@@ -9,9 +9,9 @@
 		<div id="page_wrapper">
 			<div id="bigBox">
 
-				<h1 id="win">ROYALS WIN!! :)</h1>
-				<h1 id="pizzaWin">ROYALS WIN <br/> &amp; get 1/2 off at Papa John's :p</h1>
-				<H1 id="lose">Royals lose :(</H1>
+				<h1 class="isHidden" id="win">ROYALS WIN!! :)</h1>
+				<h1 class="isHidden" id="pizzaWin">ROYALS WIN <br/> &amp; get 1/2 off at Papa John's :p</h1>
+				<H1 class="isHidden" id="lose">Royals lose :(</H1>
 
 					<p id="scoreRequest">**Please enter a score for each team below**</p>
 


### PR DESCRIPTION
I added the class "isHidden" to each of the three <h1> tags. 1. id="win" 2. id="pizzaWin" 3. id="lose". This will hide those <h1> tags when the page loads so I do not need to rely on Javascript to hide them for me.